### PR TITLE
Use fullchain.pem instead of cert.pem

### DIFF
--- a/rpm/_passbolt-configure/passbolt-configure
+++ b/rpm/_passbolt-configure/passbolt-configure
@@ -717,7 +717,7 @@ EOF
     __install_certbot
     __setup_letsencrypt 'passbolt_hostname' 'letsencrypt_email'
     __nginx_config "$script_directory/conf/nginx/passbolt_ssl.conf" "$NGINX_SITE_DIR/passbolt_ssl.conf" 'passbolt_hostname'
-    ln -sf "$LETSENCRYPT_LIVE_DIR/$passbolt_domain/cert.pem" "$SSL_CERT_PATH"
+    ln -sf "$LETSENCRYPT_LIVE_DIR/$passbolt_domain/fullchain.pem" "$SSL_CERT_PATH"
     ln -sf "$LETSENCRYPT_LIVE_DIR/$passbolt_domain/privkey.pem" "$SSL_KEY_PATH"
     __ssl_substitutions
     enable_service "$nginx_service"


### PR DESCRIPTION
The passbolt-configure setup after using RPM install, configures LetsEncrypt certificate automatically, but the nginx configuration gets only the issued certificate without the certificate chain, most browsers do not get bothered, but the Android app cannot sync via the QR code.
Simply changing the symbolic link makes it work.